### PR TITLE
bug: set project via a flag if specified

### DIFF
--- a/.github/workflows/deploy-appengine-creds-it.yml
+++ b/.github/workflows/deploy-appengine-creds-it.yml
@@ -49,7 +49,10 @@ jobs:
 
     - name: Clean Up
       if: ${{ always() }}
-      run: gcloud app services delete "${{ github.job }}-${{ github.run_number }}" --quiet
+      run: |-
+        gcloud app services delete "${{ github.job }}-${{ github.run_number }}" \
+          --quiet \
+          --project="${{ secrets.APPENGINE_DEPLOY_PROJECT_ID }}"
 
   gcloud2:
     if: ${{ github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name && github.actor != 'dependabot[bot]' }}
@@ -93,7 +96,10 @@ jobs:
 
     - name: Clean Up
       if: ${{ always() }}
-      run: gcloud app services delete "${{ github.job }}-${{ github.run_number }}" --quiet --project ${{ secrets.APPENGINE_DEPLOY_PROJECT_ID }}
+      run: |-
+        gcloud app services delete "${{ github.job }}-${{ github.run_number }}" \
+          --quiet \
+          --project="${{ secrets.APPENGINE_DEPLOY_PROJECT_ID }}"
 
   b64-json:
     if: ${{ github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name && github.actor != 'dependabot[bot]' }}
@@ -132,7 +138,10 @@ jobs:
           --retry-max-time 300
     - name: Clean Up
       if: ${{ always() }}
-      run: gcloud app services delete "${{ github.job }}-${{ github.run_number }}" --quiet
+      run: |-
+        gcloud app services delete "${{ github.job }}-${{ github.run_number }}" \
+          --quiet \
+          --project="${{ secrets.APPENGINE_DEPLOY_PROJECT_ID }}"
 
   json:
     if: ${{ github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name && github.actor != 'dependabot[bot]' }}
@@ -172,7 +181,10 @@ jobs:
 
     - name: Clean Up
       if: ${{ always() }}
-      run: gcloud app services delete "${{ github.job }}-${{ github.run_number }}" --quiet
+      run: |-
+        gcloud app services delete "${{ github.job }}-${{ github.run_number }}" \
+          --quiet \
+          --project="${{ secrets.APPENGINE_DEPLOY_PROJECT_ID }}"
 
   wif:
     if: ${{ github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name && github.actor != 'dependabot[bot]' }}
@@ -226,4 +238,7 @@ jobs:
 
     - name: Clean Up
       if: ${{ always() }}
-      run: gcloud app services delete "${{ github.job }}-${{ github.run_number }}" --quiet
+      run: |-
+        gcloud app services delete "${{ github.job }}-${{ github.run_number }}" \
+          --quiet \
+          --project="${{ secrets.APPENGINE_DEPLOY_PROJECT_ID }}"

--- a/.github/workflows/deploy-appengine-inputs-it.yml
+++ b/.github/workflows/deploy-appengine-inputs-it.yml
@@ -57,7 +57,10 @@ jobs:
           --retry-max-time 300
     - name: Clean Up
       if: ${{ always() }}
-      run: gcloud app services delete "${{ github.job }}-${{ github.run_number }}" --quiet
+      run: |-
+        gcloud app services delete "${{ github.job }}-${{ github.run_number }}" \
+          --quiet \
+          --project="${{ secrets.APPENGINE_DEPLOY_PROJECT_ID }}"
 
   bad-input:
     if: ${{ github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name && github.actor != 'dependabot[bot]' }}
@@ -85,10 +88,10 @@ jobs:
       run: |-
         if [ ${{ steps.test2.outcome }} != 'failure' ]; then exit 1; fi
 
-    # unset project id set by previous deploy 
+    # unset project id set by previous deploy
     - run: |-
         gcloud config unset project
-    
+
     - uses: google-github-actions/setup-gcloud@master
       with:
         service_account_key: ${{ secrets.APPENGINE_DEPLOY_SA_KEY_JSON }}
@@ -102,4 +105,3 @@ jobs:
     - name: Catch failure
       run: |-
         if [ ${{ steps.test1.outcome }} != 'failure' ]; then exit 1; fi
-        

--- a/.github/workflows/deploy-appengine-it.yml
+++ b/.github/workflows/deploy-appengine-it.yml
@@ -58,7 +58,10 @@ jobs:
           --retry-max-time 300
     - name: Clean Up
       if: ${{ always() }}
-      run: gcloud app services delete "${{ github.job }}-${{ github.run_number }}" --quiet
+      run: |-
+        gcloud app services delete "${{ github.job }}-${{ github.run_number }}" \
+          --quiet \
+          --project="${{ secrets.APPENGINE_DEPLOY_PROJECT_ID }}"
 
   deliverable:
     if: ${{ github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name && github.actor != 'dependabot[bot]' }}
@@ -111,8 +114,11 @@ jobs:
           --retry-max-time 300
     - name: Clean Up
       if: ${{ always() }}
-      run: gcloud app services delete "${{ github.job }}-${{ github.run_number }}" --quiet
-    
+      run: |-
+        gcloud app services delete "${{ github.job }}-${{ github.run_number }}" \
+          --quiet \
+          --project="${{ secrets.APPENGINE_DEPLOY_PROJECT_ID }}"
+
   failure:
     if: ${{ github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name && github.actor != 'dependabot[bot]' }}
     name: with bad path
@@ -153,4 +159,3 @@ jobs:
         if [ ${{ steps.deliverable.outcome }} != 'failure' ]; then
           exit 1
         fi
-        

--- a/package.json
+++ b/package.json
@@ -5,9 +5,8 @@
   "main": "dist/index.js",
   "scripts": {
     "build": "ncc build -m src/index.ts",
-    "lint": "eslint . --ext .ts,.tsx",
-    "lintfix": "eslint . --ext .ts,.tsx --fix",
-    "format": "prettier --write **.ts",
+    "lint": "eslint src/ tests/ --ext .ts,.tsx",
+    "format": "eslint src/ tests/ --ext .ts,.tsx --fix",
     "test": "mocha -r ts-node/register -t 150s 'tests/*.test.ts' --exit"
   },
   "repository": {

--- a/tests/deploy-appengine.test.ts
+++ b/tests/deploy-appengine.test.ts
@@ -50,7 +50,7 @@ describe('#run', function () {
       isAuthenticated: sinon.stub(setupGcloud, 'isAuthenticated').resolves(true),
       isInstalled: sinon.stub(setupGcloud, 'isInstalled').returns(false),
       setProject: sinon.stub(setupGcloud, 'setProject'),
-      setProjectWithKey: sinon.stub(setupGcloud, 'setProjectWithKey'),
+      parseServiceAccountKey: sinon.stub(setupGcloud, 'parseServiceAccountKey'),
       isProjectIdSet: sinon.stub(setupGcloud, 'isProjectIdSet').resolves(false),
       getExecOutput: sinon.stub(exec, 'getExecOutput'),
     };
@@ -80,7 +80,7 @@ describe('#run', function () {
     this.stubs.getInput.withArgs('credentials').returns('key');
     this.stubs.getInput.withArgs('project_id').returns('');
     await run();
-    expect(this.stubs.setProjectWithKey.withArgs('key').callCount).to.eq(1);
+    expect(this.stubs.parseServiceAccountKey.withArgs('key').callCount).to.eq(1);
   });
   it('fails if credentials and project_id are not provided', async function () {
     this.stubs.getInput.withArgs('credentials').returns('');
@@ -137,15 +137,15 @@ describe('#setUrlOutput', function () {
     target url:      [https://PROJECT_ID.uc.r.appspot.com]
 
 
-    Do you want to continue (Y/n)?  
+    Do you want to continue (Y/n)?
 
     Beginning deployment of service [default]...
     ╔════════════════════════════════════════════════════════════╗
     ╠═ Uploading 6 files to Google Cloud Storage                ═╣
     ╚════════════════════════════════════════════════════════════╝
     File upload done.
-    Updating service [default]...done.                                                                                                    
-    Setting traffic split for service [default]...done.                                                                                   
+    Updating service [default]...done.
+    Setting traffic split for service [default]...done.
     Deployed service [default] to [https://PROJECT_ID.uc.r.appspot.com]
 
     You can stream logs from the command line by running:
@@ -170,15 +170,15 @@ describe('#setUrlOutput', function () {
     target url:      [https://service-v2-dot-PROJECT_ID.uc.r.appspot.com]
 
 
-    Do you want to continue (Y/n)?  
+    Do you want to continue (Y/n)?
 
     Beginning deployment of service [service-v2]...
     ╔════════════════════════════════════════════════════════════╗
     ╠═ Uploading 1 file to Google Cloud Storage                 ═╣
     ╚════════════════════════════════════════════════════════════╝
     File upload done.
-    Updating service [service-v2]...done.                                                                                                 
-    Setting traffic split for service [service-v2]...done.                                                                                
+    Updating service [service-v2]...done.
+    Setting traffic split for service [service-v2]...done.
     Deployed service [service-v2] to [https://service-v2-dot-PROJECT_ID.uc.r.appspot.com]
 
     You can stream logs from the command line by running:


### PR DESCRIPTION
Because /auth exports the project ID as an environment variable, that environment variable takes precedence over the core property. This previously worked because setup-gcloud didn't export said environment variable. To fix this, I updated the gcloud command to use the --project flag if a project ID was given. This has the added side-effect of being able to remove all the code to configure gcloud, since it was never really necessary.

Also, I'm not sure it was ever a good idea to modify global configuration for gcloud just because someone deployed a service. Using the flag is probably the best approach here. You might notice that I added PROJECT_ID to the e2e tests. That's because they were secretly tightly coupled with the previous step that had previously run.
