### PR TITLE
chore!: upgrade to node16

### DIFF
--- a/.github/workflows/deploy-appengine-creds-it.yml
+++ b/.github/workflows/deploy-appengine-creds-it.yml
@@ -12,7 +12,7 @@ jobs:
     name: with setup-gcloud
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: google-github-actions/setup-gcloud@master
       with:
         project_id: ${{ secrets.APPENGINE_DEPLOY_PROJECT_ID }}
@@ -59,7 +59,7 @@ jobs:
     name: with setup-gcloud - no project Id
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: google-github-actions/setup-gcloud@master
       with:
         service_account_key: ${{ secrets.APPENGINE_DEPLOY_SA_KEY_JSON }}
@@ -106,7 +106,7 @@ jobs:
     name: with base64 json creds
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Update app.yaml
       run: |-
         echo "service: ${{ github.job }}-${{ github.run_number }}" >> ${{ github.workspace }}/example-app/app.yaml
@@ -148,7 +148,7 @@ jobs:
     name: with json creds
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Update app.yaml
       run: |-
         echo "service: ${{ github.job }}-${{ github.run_number }}" >> ${{ github.workspace }}/example-app/app.yaml
@@ -195,15 +195,15 @@ jobs:
       id-token: 'write'
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Update app.yaml
       run: |-
         echo "service: ${{ github.job }}-${{ github.run_number }}" >> ${{ github.workspace }}/example-app/app.yaml
 
-    - uses: 'actions/setup-node@v2'
+    - uses: 'actions/setup-node@v3'
       with:
-        node-version: '12.x'
+        node-version: '16.x'
 
     - id: build
       name: Build dist

--- a/.github/workflows/deploy-appengine-inputs-it.yml
+++ b/.github/workflows/deploy-appengine-inputs-it.yml
@@ -12,7 +12,7 @@ jobs:
     name: with flags
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: google-github-actions/setup-gcloud@master
       with:
         project_id: ${{ secrets.APPENGINE_DEPLOY_PROJECT_ID }}
@@ -67,10 +67,10 @@ jobs:
     name: with bad inputs
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@master
+    - uses: actions/checkout@v3
+    - uses: actions/setup-node@v3
       with:
-        node-version: 12.x
+        node-version: 16.x
     - id: build
       name: Build dist
       run: |-

--- a/.github/workflows/deploy-appengine-it.yml
+++ b/.github/workflows/deploy-appengine-it.yml
@@ -12,7 +12,7 @@ jobs:
     name: with working directory
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: google-github-actions/setup-gcloud@master
       with:
         project_id: ${{ secrets.APPENGINE_DEPLOY_PROJECT_ID }}
@@ -68,7 +68,7 @@ jobs:
     name: with deliverable path
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: google-github-actions/setup-gcloud@master
       with:
         project_id: ${{ secrets.APPENGINE_DEPLOY_PROJECT_ID }}
@@ -124,7 +124,7 @@ jobs:
     name: with bad path
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: google-github-actions/setup-gcloud@master
       with:
         project_id: ${{ secrets.APPENGINE_DEPLOY_PROJECT_ID }}

--- a/.github/workflows/example-workflow.yaml
+++ b/.github/workflows/example-workflow.yaml
@@ -30,7 +30,7 @@ jobs:
 
     runs-on: 'ubuntu-latest'
     steps:
-    - uses: 'actions/checkout@v2'
+    - uses: 'actions/checkout@v3'
 
     - uses: 'google-github-actions/auth@v0'
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,11 +12,11 @@ jobs:
   build:
     runs-on: 'ubuntu-latest'
     steps:
-    - uses: 'actions/checkout@v2'
+    - uses: 'actions/checkout@v3'
 
-    - uses: 'actions/setup-node@v2'
+    - uses: 'actions/setup-node@v3'
       with:
-        node-version: '12.x'
+        node-version: '16.x'
 
     - name: 'npm build'
       run: 'npm ci && npm run build'

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -25,11 +25,11 @@ jobs:
         - 'macos-latest'
 
     steps:
-    - uses: 'actions/checkout@v2'
+    - uses: 'actions/checkout@v3'
 
-    - uses: 'actions/setup-node@v2'
+    - uses: 'actions/setup-node@v3'
       with:
-        node-version: 12.x
+        node-version: 16.x
 
     - name: 'npm build'
       run: 'npm ci && npm run build'

--- a/README.md
+++ b/README.md
@@ -24,8 +24,13 @@ background if not using in with the [`setup-gcloud` action][setup-gcloud].
 
 ## Prerequisites
 
-This action requires Google Cloud credentials that are authorized to deploy an
-App Engine Application. See the [Authorization](#authorization) section below for more information.
+-   This action requires Google Cloud credentials that are authorized to deploy
+    an App Engine Application. See the [Authorization](#authorization) section
+    below for more information.
+
+-   This action runs using Node 16. If you are using self-hosted GitHub Actions
+    runners, you must use runner version [2.285.0](https://github.com/actions/virtual-environments)
+    or newer.
 
 ## Usage
 

--- a/action.yml
+++ b/action.yml
@@ -64,7 +64,7 @@ inputs:
   flags:
     description: |-
       Space separated list of other App Engine flags, examples can be found:
-      https://cloud.google.com/sdk/gcloud/reference/app/deploy#FLAGS. Ex 
+      https://cloud.google.com/sdk/gcloud/reference/app/deploy#FLAGS. Ex
       --service-account=my-account@project.iam.gserviceaccount.com --no-cache
     required: false
 
@@ -72,6 +72,10 @@ outputs:
   url:
     description: URL of your App Engine Application
 
+branding:
+  icon: 'code'
+  color: 'blue'
+
 runs:
-  using: node12
-  main: dist/index.js
+  using: 'node16'
+  main: 'dist/index.js'

--- a/example-app/app.yaml
+++ b/example-app/app.yaml
@@ -1,9 +1,9 @@
 # Copyright 2020 Google, LLC.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #    http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-runtime: nodejs12
+runtime: nodejs16


### PR DESCRIPTION
Most of these changes were already landed, but I reverted them to land the 0.7 release which was the last to support Node 12.

Fixes https://github.com/google-github-actions/deploy-appengine/issues/241