### PR TITLE
Improve cleanup script

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -2,7 +2,7 @@ name: 'Cleanup'
 
 on:
   schedule:
-    - cron: '0 */4 * * *'
+    - cron: '0 */6 * * *'
   workflow_dispatch:
 
 permissions:
@@ -25,11 +25,13 @@ jobs:
 
     - name: Delete services
       run: |-
-        BUFFER="$(TZ=GMT+4 date +%Y-%m-%d)"
-
         gcloud config set core/project "${{ secrets.PROJECT_ID }}"
 
-        (IFS=$'\n'; for NAME in $(gcloud app versions list --format="value(id)" --filter="service != "default" AND version.createTime.date('%Y-%m-%d', Z) < '${BUFFER}'"); do
+        # List and delete all versions that were deployed 30 minutes ago or
+        # earlier. The date math here is a little weird, but we're looking for
+        # deployments "earlier than" 30 minutes ago, so it's less than since
+        # time increases.
+        (IFS=$'\n'; for NAME in $(gcloud app versions list --format="value(id)" --filter="service != "default" AND version.createTime < '-pt30m'"); do
           echo "Deleting ${NAME}..."
           gcloud app versions delete ${NAME} --quiet
         done)


### PR DESCRIPTION
Apparently gcloud can handle relative dates already. Also slightly reduce the run frequency.