### PR TITLE
docs: replace old parameter on example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ jobs:
 
     # Example of using the output
     - id: 'test'
-      run: 'curl "${{ steps.deploy.outputs.url }}"'
+      run: 'curl "${{ steps.deploy.outputs.version_url }}"'
 ```
 
 ## Inputs


### PR DESCRIPTION
<!--
Thank you for proposing a pull request! Please note that SOME TESTS WILL
LIKELY FAIL due to how GitHub exposes secrets in Pull Requests from forks.
Someone from the team will review your Pull Request and respond.

Please describe your change and any implementation details below.
-->

Hi maintainers, thank you for the awesome project.

I think that `outputs.url` seems to be deprecated parameter because it's not included in README.md[^1] now and it returns same value of `outputs.version_url`[^2].
so I replaced `outputs.url` to `outputs.version_url` on example code on README.md

[^1]: https://github.com/google-github-actions/deploy-appengine/blob/abf67aa4ea465aee02104003e9f377d8ec976ade/README.md#outputs
[^2]: https://github.com/google-github-actions/deploy-appengine/blob/abf67aa4ea465aee02104003e9f377d8ec976ade/src/main.ts#L248-L253
