### PR TITLE
Docs: Added artifact register reader permission required for ci/cd pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,8 @@ There are a few ways to authenticate this action. The caller must have the follo
 -   Cloud Build Editor (`roles/cloudbuild.builds.editor`) to build the
     service.
 
+-   Artifact Registry Reader (`roles/artifactregistry.reader`) to view & get artifacts for implementing CI/CD pipeline.
+
 -   Service Account User (`roles/iam.serviceAccountUser`) permissions on the
     runtime service account to deploy the service. The default runtime service
     account is `PROJECT_ID@appspot.gserviceaccount.com`, but you can also


### PR DESCRIPTION
Hi maintainers. This PR is based on #354 

Found an issue that when deploying to App engine via github actions for standard environment, you get logs with this error `reason: generic::permission_denied: failed to fetch manifest: generic::permission_denied` which is due to `Artifact Registry Reader` Permission missing from service account used. I did not encounter this issue for flexible environment.
Tested with following configurations
`deploy.yaml` ( github workflow )
```
name: Deploy to GAE

on:
  # Triggers the workflow on push or pull request events but only for the main branch
  push:
    branches: [ main ]

jobs:
  deploy:
    name: Deploying to Google Cloud
    runs-on: ubuntu-latest
    
    steps:
    - name: Checkout
      uses: actions/checkout@v4

    - name: 'Auth GCP'
      uses: 'google-github-actions/auth@v2'
      with:
        credentials_json: '${{ secrets.GCP_DEPLOY }}'

    - id: deploy
      name: Deploy to App Engine
      uses: google-github-actions/deploy-appengine@v2
      with:
        deliverables: app.yaml
        project_id: ${{ secrets.GCP_PROJECT }}

    - name: Test output
      run: 'curl "${{ steps.deploy.outputs.version_url }}"'
```

`app.yaml`
```
service: default
runtime: nodejs18
env: standard
instance_class: F1

env_variables:
  NODE_ENV: production
  PORT: 8080

inbound_services:
- warmup

automatic_scaling:
  min_instances: 1
  max_instances: 2
  target_cpu_utilization: 0.75


handlers:
- url: /.*
  script: auto
  secure: always
  redirect_http_response_code: 301
```