### PR TITLE
Default "promote" to true

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -93,7 +93,7 @@ export async function run(): Promise<void> {
     const envVars = parseKVString(getInput('env_vars'));
     const imageUrl = presence(getInput('image_url'));
     const version = presence(getInput('version'));
-    const promote = parseBoolean(getInput('promote'));
+    const promote = parseBoolean(getInput('promote'), true);
     const flags = presence(getInput('flags'));
     const gcloudVersion = await computeGcloudVersion(getInput('gcloud_version'));
     const gcloudComponent = presence(getInput('gcloud_component'));

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -229,6 +229,16 @@ test('#run', { concurrency: true }, async (suite) => {
     assertMembers(mocks.getExecOutput.mock.calls?.at(0)?.arguments?.at(1), ['--promote']);
   });
 
+  await suite.test('sets promote if given the empty string', async (t) => {
+    const mocks = defaultMocks(t.mock, {
+      promote: '',
+    });
+
+    await run();
+
+    assertMembers(mocks.getExecOutput.mock.calls?.at(0)?.arguments?.at(1), ['--promote']);
+  });
+
   await suite.test('sets no-promote if given', async (t) => {
     const mocks = defaultMocks(t.mock, {
       promote: 'false',


### PR DESCRIPTION
This restores a v0 and v1 behavior wherein the empty string is considered "true" instead of "false". Fixes GH-361.