### PR TITLE
Make `project_id` an optional input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ inputs:
     description: |-
       The Google Cloud Project ID. If unspecified, it is inherited from the
       environment.
-    required: true
+    required: false
 
   working_directory:
     description: |-


### PR DESCRIPTION
The code and readme specify the `project_id` as optional, but it is marked as required in the `action.yml` file. Marking it as optional

<!--
Thank you for proposing a pull request! Please note that SOME TESTS WILL
LIKELY FAIL due to how GitHub exposes secrets in Pull Requests from forks.
Someone from the team will review your Pull Request and respond.

Please describe your change and any implementation details below.
-->
