### PR TITLE
Remove optional project_id field

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -53,7 +53,6 @@ jobs:
         id: 'deploy'
         uses: './'
         with:
-          project_id: '${{ vars.PROJECT_ID }}'
           working_directory: '${{ github.workspace }}/example-app'
           build_env_vars: |-
             FOO=bar


### PR DESCRIPTION
Now that https://github.com/google-github-actions/deploy-appengine/pull/383 is merged, we can make this optional.